### PR TITLE
Fix compiling with MinGW

### DIFF
--- a/sse/matrix.hpp
+++ b/sse/matrix.hpp
@@ -1237,7 +1237,7 @@ inline const Matrix4 Matrix4::perspective(float fovyRadians, float aspect, float
     SSEFloat tmp;
     __m128 col0, col1, col2, col3;
 
-    f = std::tanf(VECTORMATH_PI_OVER_2 - fovyRadians * 0.5f);
+    f = tanf(VECTORMATH_PI_OVER_2 - fovyRadians * 0.5f);
     rangeInv = 1.0f / (zNear - zFar);
     const __m128 zero = _mm_setzero_ps();
     tmp.m128 = zero;

--- a/vec2d.hpp
+++ b/vec2d.hpp
@@ -463,7 +463,7 @@ inline const Vector2 operator * (float scalar, const Vector2 & vec)
 
 inline const Vector2 absPerElem(const Vector2 & vec)
 {
-    return Vector2(std::fabsf(vec.getX()), std::fabsf(vec.getY()));
+    return Vector2(fabsf(vec.getX()), fabsf(vec.getY()));
 }
 
 inline const Vector2 maxPerElem(const Vector2 & vec0, const Vector2 & vec1)
@@ -506,13 +506,13 @@ inline float lengthSqr(const Vector2 & vec)
 
 inline float length(const Vector2 & vec)
 {
-    return std::sqrtf(lengthSqr(vec));
+    return sqrtf(lengthSqr(vec));
 }
 
 inline const Vector2 normalize(const Vector2 & vec)
 {
     const float lenSqr = lengthSqr(vec);
-    const float lenInv = (1.0f / std::sqrtf(lenSqr));
+    const float lenInv = (1.0f / sqrtf(lenSqr));
     return Vector2((vec.getX() * lenInv), (vec.getY() * lenInv));
 }
 
@@ -628,7 +628,7 @@ inline Point2 & Point2::operator -= (const Vector2 & vec)
 
 inline const Point2 absPerElem(const Point2 & pnt)
 {
-    return Point2(std::fabsf(pnt.getX()), std::fabsf(pnt.getY()));
+    return Point2(fabsf(pnt.getX()), fabsf(pnt.getY()));
 }
 
 inline const Point2 maxPerElem(const Point2 & pnt0, const Point2 & pnt1)


### PR DESCRIPTION
Some math functions in cmath are not in the namespace std, like tanf, fabsf, sqrtf, ...

This problem is not only related to MinGW some GCC versions have the same issue.

It is generally safe to remove std:: for all math functions.